### PR TITLE
Fix title padding

### DIFF
--- a/lib/ui/common/main_app_bar.dart
+++ b/lib/ui/common/main_app_bar.dart
@@ -26,6 +26,7 @@ class MainAppBar extends StatelessWidget {
       expandedHeight: expandedHeight,
       bottom: bottom,
       flexibleSpace: FlexibleSpaceBar(
+        titlePadding: const EdgeInsets.symmetric(vertical: 16.0),
         centerTitle: true,
         title: title,
         background: _BackgroundImage(


### PR DESCRIPTION
After updating Flutter, the title padding became misaligned. This change maintains the original padding.