### PR TITLE
fix: Revert test version to 1.24.9

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dev_dependencies:
   flutter_lints: ^3.0.2
   flutter_native_splash: ^2.4.0
   flutter_launcher_icons: ^0.13.1
-  test: ^1.25.2
+  test: ^1.24.9
   dart_pre_commit: ^5.3.0
   git_hooks: ^1.0.1
 


### PR DESCRIPTION
addressing workflow failure for flutter pub get