### PR TITLE
chore: remove build apk step from flutter ci

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -67,17 +67,17 @@ jobs:
         run: flutter pub get
       - name: Run flutter test
         run: flutter test
-      - name: Build APK
-        id: build-apk
-        run: flutter build apk --split-per-abi
+      # - name: Build APK
+      #   id: build-apk
+      #   run: flutter build apk --split-per-abi
+      # - name: Archive APK
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: release-apk
+      #     path: build/app/outputs/flutter-apk/
       - name: Build App Bundle
         id: build-app-bundle
         run: flutter build appbundle
-      - name: Archive APK
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-apk
-          path: build/app/outputs/flutter-apk/
       - name: Archive App Bundle
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Removing the APK build step since it takes so long (>5 mins) compared to App Bundle build (<1 min)