### PR TITLE
fix: Update base64 decode step for Android build

### DIFF
--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -49,7 +49,7 @@ jobs:
           DECODED_KEYSTORE_PATH: "android/app/${{ secrets.STORE_FILE }}"
         run: |
           echo $ENCODED_KEYSTORE > keystore_base64.txt
-          base64 -d keystore_base64.txt > $DECODED_KEYSTORE_PATH
+          base64 -d -i keystore_base64.txt -o $DECODED_KEYSTORE_PATH
       - name: Populate android/key.properties
         env:
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}


### PR DESCRIPTION
Build is failing at

```sh
base64 -d keystore_base64.txt > $DECODED_KEYSTORE_PATH
```

Example: https://github.com/airicbear/ateez_lyrics/actions/runs/9361171805/job/25767718711