### PR TITLE
fix: Remove version number from test dependency to fix build issue

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dev_dependencies:
   flutter_lints: ^4.0.0
   flutter_native_splash: ^2.4.0
   flutter_launcher_icons: ^0.13.1
-  test: ^1.25.5
+  test:
   dart_pre_commit: ^5.3.0
   git_hooks: ^1.0.1
 


### PR DESCRIPTION
Address build issue with dependency versions.

Build: https://github.com/airicbear/ateez_lyrics/actions/runs/9429710466/job/25976396256

Error:

```
Run flutter pub get
Resolving dependencies...
Note: test_api is pinned to version 0.7.0 by flutter_test from the flutter SDK.
See https://dart.dev/go/sdk-version-pinning for details.


Because test >=1.25.6 depends on test_api 0.7.2 and no versions of test match >1.25.5 <1.25.6, test >1.25.5 requires test_api 0.7.2.
And because test 1.25.5 depends on test_api 0.7.1 and every version of flutter_test from sdk depends on test_api 0.7.0, test >=1.25.5 is incompatible with flutter_test from sdk.
So, because ateez_lyrics depends on both flutter_test from sdk and test ^1.25.5, version solving failed.


You can try the following suggestion to make the pubspec resolve:
* Consider downgrading your constraint on test: flutter pub add dev:test:^1.25.2
Error: Process completed with exit code 1.
```